### PR TITLE
don't inject the entity into the render state

### DIFF
--- a/common/src/main/java/betterblockentities/client/render/immediate/blockentity/extentions/BlockEntityRenderStateExt.java
+++ b/common/src/main/java/betterblockentities/client/render/immediate/blockentity/extentions/BlockEntityRenderStateExt.java
@@ -1,9 +1,4 @@
 package betterblockentities.client.render.immediate.blockentity.extentions;
 
-/* minecraft */
-import net.minecraft.world.level.block.entity.BlockEntity;
-
-public interface BlockEntityRenderStateExt {
-    void bbe$setBlockEntity(BlockEntity blockEntity);
-    BlockEntity bbe$getBlockEntity();
+public interface BlockEntityRenderStateExt extends BlockEntityExt {
 }

--- a/common/src/main/java/betterblockentities/client/render/immediate/overlay/OverlayRenderer.java
+++ b/common/src/main/java/betterblockentities/client/render/immediate/overlay/OverlayRenderer.java
@@ -2,10 +2,10 @@ package betterblockentities.client.render.immediate.overlay;
 
 /* local */
 import betterblockentities.client.render.immediate.blockentity.extentions.BlockEntityRenderStateExt;
-
-/* minecraft */
 import betterblockentities.client.render.immediate.blockentity.manager.InstancedBlockEntityManager;
 import betterblockentities.platform.GlobalScope;
+
+/* minecraft */
 import net.minecraft.client.model.Model;
 import net.minecraft.client.model.object.banner.BannerFlagModel;
 import net.minecraft.client.renderer.blockentity.BlockEntityRenderDispatcher;

--- a/common/src/main/java/betterblockentities/client/render/immediate/overlay/OverlayRenderer.java
+++ b/common/src/main/java/betterblockentities/client/render/immediate/overlay/OverlayRenderer.java
@@ -4,6 +4,7 @@ package betterblockentities.client.render.immediate.overlay;
 import betterblockentities.client.render.immediate.blockentity.extentions.BlockEntityRenderStateExt;
 
 /* minecraft */
+import betterblockentities.client.render.immediate.blockentity.manager.InstancedBlockEntityManager;
 import betterblockentities.platform.GlobalScope;
 import net.minecraft.client.model.Model;
 import net.minecraft.client.model.object.banner.BannerFlagModel;
@@ -15,8 +16,6 @@ import net.minecraft.client.renderer.rendertype.RenderType;
 import net.minecraft.client.renderer.state.level.CameraRenderState;
 import net.minecraft.client.renderer.texture.OverlayTexture;
 import net.minecraft.client.resources.model.ModelBakery;
-import net.minecraft.world.level.block.entity.BannerBlockEntity;
-import net.minecraft.world.level.block.entity.BlockEntity;
 
 /* mojang */
 import com.mojang.blaze3d.vertex.PoseStack;
@@ -26,11 +25,10 @@ public final class OverlayRenderer {
 
     public static void submitCrumblingOverlay(BlockEntityRenderDispatcher dispatcher, BlockEntityRenderState state, PoseStack poseStack, CameraRenderState camera) {
         BlockEntityRenderStateExt renderStateExt = (BlockEntityRenderStateExt) state;
-        BlockEntity blockEntity = renderStateExt.bbe$getBlockEntity();
 
         OverlayNodeStorage.SubmitParameters parameters;
 
-        if (blockEntity instanceof BannerBlockEntity) {
+        if (renderStateExt.bbe$getOptKind() == InstancedBlockEntityManager.OptKind.BANNER) {
             parameters = new OverlayNodeStorage.SubmitParameters(
                     call -> call.model() instanceof BannerFlagModel ?
                     new OverlayNodeStorage.SubmitResolution(

--- a/common/src/main/java/betterblockentities/mixin/render/LevelRendererMixin.java
+++ b/common/src/main/java/betterblockentities/mixin/render/LevelRendererMixin.java
@@ -2,7 +2,6 @@ package betterblockentities.mixin.render;
 
 /* local */
 import betterblockentities.client.gui.config.BBEConfig;
-import betterblockentities.client.render.immediate.blockentity.extentions.BlockEntityExt;
 import betterblockentities.client.render.immediate.blockentity.extentions.BlockEntityRenderStateExt;
 import betterblockentities.client.render.immediate.blockentity.misc.RenderingMode;
 import betterblockentities.client.render.immediate.overlay.OverlayRenderer;
@@ -17,7 +16,6 @@ import net.minecraft.client.renderer.blockentity.state.BlockEntityRenderState;
 import net.minecraft.client.renderer.state.level.CameraRenderState;
 import net.minecraft.client.renderer.state.level.LevelRenderState;
 import net.minecraft.core.BlockPos;
-import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.phys.Vec3;
 
 /* mojang */
@@ -54,13 +52,10 @@ public class LevelRendererMixin {
     private void bbe$submitBreakingOverlays(BlockEntityRenderDispatcher instance, BlockEntityRenderState state, PoseStack poseStack, SubmitNodeCollector submitNodeCollector, CameraRenderState camera, Operation<Void> original) {
         BlockEntityRenderStateExt renderStateExt = (BlockEntityRenderStateExt)state;
 
-        BlockEntity blockEntity = renderStateExt.bbe$getBlockEntity();
-        BlockEntityExt blockEntityExt = (BlockEntityExt)blockEntity;
-
-        if (blockEntityExt.bbe$isSupportedBlockEntity() &&
-            BBEConfig.OptEnabledTable.ENABLED[blockEntityExt.bbe$getOptKind() & 0xFF] &&
-            blockEntityExt.bbe$getRenderingMode() == RenderingMode.TERRAIN &&
-            blockEntityExt.bbe$isTerrainMeshReady() &&
+        if (renderStateExt.bbe$isSupportedBlockEntity() &&
+            BBEConfig.OptEnabledTable.ENABLED[renderStateExt.bbe$getOptKind() & 0xFF] &&
+            renderStateExt.bbe$getRenderingMode() == RenderingMode.TERRAIN &&
+            renderStateExt.bbe$isTerrainMeshReady() &&
             state.breakProgress != null)
         {
             OverlayRenderer.submitCrumblingOverlay(instance, state, poseStack, camera);

--- a/common/src/main/java/betterblockentities/mixin/render/immediate/blockentity/extentions/BlockEntityRenderStateMixin.java
+++ b/common/src/main/java/betterblockentities/mixin/render/immediate/blockentity/extentions/BlockEntityRenderStateMixin.java
@@ -1,7 +1,9 @@
 package betterblockentities.mixin.render.immediate.blockentity.extentions;
 
 /* local */
+import betterblockentities.client.render.immediate.blockentity.extentions.BlockEntityExt;
 import betterblockentities.client.render.immediate.blockentity.extentions.BlockEntityRenderStateExt;
+import betterblockentities.client.render.immediate.blockentity.misc.RenderingMode;
 
 /* minecraft */
 import net.minecraft.client.renderer.blockentity.state.BlockEntityRenderState;
@@ -17,14 +19,70 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 @Mixin(BlockEntityRenderState.class)
 public class BlockEntityRenderStateMixin implements BlockEntityRenderStateExt {
-    @Unique private BlockEntity blockEntity;
+    @Unique private RenderingMode renderingMode = RenderingMode.TERRAIN;
+    @Unique private boolean terrainMeshReady = true;
+    @Unique private boolean hasSpecialManager = false;
+    @Unique private byte bbeKind = 0;
+    @Unique private boolean supportedBlockEntity = false;
 
     @Inject(method = "extractBase", at = @At("TAIL"))
     private static void bbe$fillBaseState(BlockEntity blockEntity, BlockEntityRenderState state, ModelFeatureRenderer.CrumblingOverlay breakProgress, CallbackInfo ci) {
         BlockEntityRenderStateExt renderStateExt = (BlockEntityRenderStateExt)state;
-        renderStateExt.bbe$setBlockEntity(blockEntity);
+        BlockEntityExt blockEntityExt = (BlockEntityExt)blockEntity;
+        renderStateExt.bbe$setRenderingMode(blockEntityExt.bbe$getRenderingMode());
+        renderStateExt.bbe$setTerrainMeshReady(blockEntityExt.bbe$isTerrainMeshReady());
+        renderStateExt.bbe$setSpecialManager(blockEntityExt.bbe$hasSpecialManager());
+        renderStateExt.bbe$setOptKind(blockEntityExt.bbe$getOptKind());
+        renderStateExt.bbe$setSupportedBlockEntity(blockEntityExt.bbe$isSupportedBlockEntity());
     }
 
-    @Override public void bbe$setBlockEntity(BlockEntity blockEntity) { this.blockEntity = blockEntity; }
-    @Override public BlockEntity bbe$getBlockEntity() { return this.blockEntity; }
+    @Override
+    public boolean bbe$isSupportedBlockEntity() {
+        return supportedBlockEntity;
+    }
+
+    @Override
+    public void bbe$setSupportedBlockEntity(boolean bl) {
+        supportedBlockEntity = bl;
+    }
+
+    @Override
+    public RenderingMode bbe$getRenderingMode() {
+        return renderingMode;
+    }
+
+    @Override
+    public void bbe$setRenderingMode(RenderingMode mode) {
+        renderingMode = mode;
+    }
+
+    @Override
+    public boolean bbe$isTerrainMeshReady() {
+        return terrainMeshReady;
+    }
+
+    @Override
+    public void bbe$setTerrainMeshReady(boolean b) {
+        terrainMeshReady = b;
+    }
+
+    @Override
+    public boolean bbe$hasSpecialManager() {
+        return hasSpecialManager;
+    }
+
+    @Override
+    public void bbe$setSpecialManager(boolean bl) {
+        hasSpecialManager = bl;
+    }
+
+    @Override
+    public byte bbe$getOptKind() {
+        return bbeKind;
+    }
+
+    @Override
+    public void bbe$setOptKind(byte k) {
+        bbeKind = k;
+    }
 }


### PR DESCRIPTION
It's very bad practice to just inject the entity into the render state.
I made the render state extension just extend the block entity extension cuz that was easier and there would be a lot of overlap in the methods, tell me if you want it to be separate.

That's about it I think

Fixes #150 