### PR TITLE
Sable compat: keep sublevel block entities on the vanilla BER path

### DIFF
--- a/README-SABLE-FIX.md
+++ b/README-SABLE-FIX.md
@@ -1,0 +1,76 @@
+# BBE Sable Fix (fork)
+
+Fork of **Better Block Entities (BBE)** `1.3.4-beta.3+mc1.21.1` for **NeoForge 1.21.1**,
+fixing invisible block entities placed on **Sable / Create: Aeronautics** sublevels
+(contraptions).
+
+- Upstream: https://github.com/EdeenMC/betterblockentities
+- Base: `1.21.1-backport` branch tip (`17b1ba7`, "mod version bump" = `1.3.4-beta.3+mc1.21.1`,
+  the most recent NeoForge 1.21.1 release on Modrinth)
+- Branch in this fork: `sable-fix`
+- Built jar: `../bbe-neoforge-1.3.4-beta.3-sablefix+mc1.21.1.jar`
+  (renamed copy of `build/mod/bbe-neoforge-1.3.4-beta.3+mc1.21.1.jar` for clarity;
+  internal mod version is unchanged so it stays a drop-in replacement)
+
+## The bug
+
+BBE assumes every supported block entity lives in main-world terrain meshed by
+Sodium. A new block entity defaults to `renderingMode=TERRAIN` +
+`terrainMeshReady=true`, so BBE's `BlockEntityRenderDispatcher` mixin immediately
+culls the vanilla block-entity renderer (BER) and waits for Sodium to bake the
+model into the terrain chunk.
+
+Sable sublevels are **not** meshed by Sodium's main-world pipeline. They live in
+isolated plot chunks and are rendered by Sable's own `SubLevelRenderDispatcher`,
+which collects block entities for vanilla BER rendering and never bakes BBE
+static terrain models. Net effect: a block entity placed on a contraption is
+culled from the BER path while no terrain mesh ever appears for it — invisible.
+Interacting with it flips BBE into `IMMEDIATE` mode, re-enabling BER, which is
+exactly the reported "culled until you interact with it" symptom.
+
+## The fix
+
+New helper `common/.../client/compat/SableCompat.java` detects (via reflection,
+so Sable stays an **optional** dependency — no crash and zero behaviour change
+when Sable isn't installed) whether a block entity is inside a Sable sublevel
+(`Sable.HELPER.getContaining(BlockEntity)`), and such block entities are kept on
+the vanilla path permanently:
+
+1. `BlockEntityRenderDispatcherMixin.shouldManage()` returns `false` for sublevel
+   BEs → vanilla BER is never culled for them.
+2. `InstancedBlockEntityManager.run()/tick()/trigger()` pins sublevel BEs to
+   `IMMEDIATE` + `terrainMeshReady=false` and never queues main-world section
+   rebuilds for their plot positions.
+3. `BBEBlockRenderer.emitBlockModel()` skips baking sublevel BEs into Sodium
+   main-world terrain.
+4. `ChunkBuilderMeshingTaskMixin` leaves sublevel BEs at their vanilla render
+   shape instead of forcing `MODEL`.
+5. `LidControllerSync.setImmediate()` skips the (useless) main-world rebuild for
+   sublevel chests.
+
+## Build
+
+Requires JDK 21 (project targets Java 21; e.g. Temurin 21):
+
+```powershell
+$env:JAVA_HOME = "C:\Program Files\Eclipse Adoptium\jdk-21.0.12.101-hotspot"
+.\gradlew.bat :neoforge:modJar -Pbuild.release --console=plain
+# -> build/mod/bbe-neoforge-1.3.4-beta.3+mc1.21.1.jar
+```
+
+Verified: `BUILD SUCCESSFUL`, and the jar contains
+`betterblockentities/client/compat/SableCompat.class`.
+
+## Install / test
+
+1. Minecraft 1.21.1 + NeoForge 21.1.228 + Sodium 0.8.12 + Sable + Create: Aeronautics.
+2. Remove upstream BBE, drop in this jar (client-side).
+3. Place a chest/sign/barrel-class BE on a contraption sublevel → it should render
+   immediately without needing interaction. Main-world BEs should behave exactly
+   as upstream (meshed into terrain, animated via BER when opened).
+
+## Notes
+
+- No new dependencies; Sable detection is soft (reflection with fail-open to
+  upstream behaviour).
+- License: same as upstream (LGPL-3.0-or-later).

--- a/common/src/main/java/betterblockentities/client/chunk/pipeline/BBEBlockRenderer.java
+++ b/common/src/main/java/betterblockentities/client/chunk/pipeline/BBEBlockRenderer.java
@@ -2,6 +2,7 @@ package betterblockentities.client.chunk.pipeline;
 
 /* local */
 import betterblockentities.client.chunk.util.ModelResourceUtil;
+import betterblockentities.client.compat.SableCompat;
 import betterblockentities.client.gui.config.BBEConfig;
 import betterblockentities.client.gui.config.ConfigCache;
 import betterblockentities.client.gui.option.EnumTypes;
@@ -79,6 +80,12 @@ public final class BBEBlockRenderer {
         }
 
         if (AltRenderers.hasRendererOverride(blockEntity.getType())) {
+            return;
+        }
+
+        // Sable compat: never bake sublevel (contraption) block entities into main-world
+        // Sodium terrain. Sable renders its plots with its own dispatcher + vanilla BERs.
+        if (SableCompat.isOnSubLevel(blockEntity)) {
             return;
         }
 

--- a/common/src/main/java/betterblockentities/client/compat/SableCompat.java
+++ b/common/src/main/java/betterblockentities/client/compat/SableCompat.java
@@ -1,0 +1,103 @@
+package betterblockentities.client.compat;
+
+import net.minecraft.world.level.block.entity.BlockEntity;
+
+/**
+ * Compatibility with Sable (Create: Aeronautics' physics engine).
+ *
+ * <p>Root cause of the reported bug: Better Block Entities assumes every supported
+ * block entity lives in the main {@code ClientLevel} terrain meshed by Sodium.
+ * A newly constructed block entity defaults to {@code renderingMode=TERRAIN} with
+ * {@code terrainMeshReady=true}, so {@link
+ * betterblockentities.mixin.render.immediate.blockentity.BlockEntityRenderDispatcherMixin}
+ * immediately culls the vanilla block-entity renderer (BER) and waits for Sodium to
+ * mesh the model into the terrain chunk.</p>
+ *
+ * <p>Sable sublevels (contraptions) are <em>not</em> meshed by Sodium's main-world
+ * pipeline. They live in isolated plot chunks (far-away "shadow" positions) and are
+ * rendered by Sable's own {@code SubLevelRenderDispatcher}, which collects block
+ * entities for vanilla BER rendering and never bakes BBE's static terrain models.
+ * The result: a block entity placed on a contraption is culled from the BER path
+ * while no terrain mesh ever appears for it, so it stays invisible. Interacting
+ * with it (e.g. opening a chest) flips BBE into {@code IMMEDIATE} mode, which
+ * re-enables the BER path -- matching the reported "invisible until interacted
+ * with" symptom exactly.</p>
+ *
+ * <p>Fix: detect block entities that live inside a Sable sublevel and keep them on
+ * the vanilla BER path permanently -- never cull them, never bake them into
+ * Sodium terrain, and never queue main-world section rebuilds for their plot
+ * positions.</p>
+ *
+ * <p>This class uses reflection so Sable remains an <em>optional</em> dependency:
+ * when Sable is not installed every check cheaply returns {@code false} and BBE
+ * behaves exactly as upstream.</p>
+ */
+public final class SableCompat {
+    private SableCompat() {}
+
+    private static volatile Boolean sableLoaded;
+    private static volatile Object sableHelper;
+    private static volatile java.lang.reflect.Method getContainingByBlockEntity;
+
+    /**
+     * @return true if the Sable mod classes are present on the classpath.
+     */
+    public static boolean isSableLoaded() {
+        Boolean cached = sableLoaded;
+        if (cached != null) {
+            return cached;
+        }
+        boolean loaded = false;
+        try {
+            Class<?> sableClass = Class.forName("dev.ryanhcode.sable.Sable");
+            java.lang.reflect.Field helperField = sableClass.getField("HELPER");
+            Object helper = helperField.get(null);
+            if (helper != null) {
+                java.lang.reflect.Method method =
+                        helper.getClass().getMethod("getContaining", BlockEntity.class);
+                sableHelper = helper;
+                getContainingByBlockEntity = method;
+                loaded = true;
+            }
+        } catch (Throwable ignored) {
+            loaded = false;
+        }
+        sableLoaded = loaded;
+        return loaded;
+    }
+
+    /**
+     * Checks whether the given block entity lives inside a Sable sublevel plot.
+     * Safe to call from render threads and chunk-meshing worker threads: any
+     * failure fails open to {@code false} (upstream BBE behaviour).
+     *
+     * @param blockEntity the block entity to test (may be null)
+     * @return true if Sable reports this block entity as contained in a sublevel
+     */
+    public static boolean isOnSubLevel(BlockEntity blockEntity) {
+        if (blockEntity == null) {
+            return false;
+        }
+        try {
+            if (blockEntity.getLevel() == null) {
+                return false;
+            }
+        } catch (Throwable ignored) {
+            return false;
+        }
+        if (!isSableLoaded()) {
+            return false;
+        }
+        try {
+            Object helper = sableHelper;
+            java.lang.reflect.Method method = getContainingByBlockEntity;
+            if (helper == null || method == null) {
+                return false;
+            }
+            Object subLevel = method.invoke(helper, blockEntity);
+            return subLevel != null;
+        } catch (Throwable ignored) {
+            return false;
+        }
+    }
+}

--- a/common/src/main/java/betterblockentities/client/render/immediate/blockentity/manager/InstancedBlockEntityManager.java
+++ b/common/src/main/java/betterblockentities/client/render/immediate/blockentity/manager/InstancedBlockEntityManager.java
@@ -4,6 +4,7 @@ package betterblockentities.client.render.immediate.blockentity.manager;
 import betterblockentities.platform.GlobalScope;
 import betterblockentities.render.AltRenderers;
 import betterblockentities.client.chunk.section.SectionUpdateDispatcher;
+import betterblockentities.client.compat.SableCompat;
 import betterblockentities.client.gui.config.BBEConfig;
 import betterblockentities.client.gui.config.ConfigCache;
 import betterblockentities.client.gui.option.EnumTypes;
@@ -97,6 +98,18 @@ public final class InstancedBlockEntityManager {
      *   FINISHED   -> safe to remove from queue
      */
     public int run() {
+        // Sable compat: sublevel (contraption) block entities are rendered by Sable itself.
+        // Keep them on the vanilla BER path and never queue main-world terrain rebuilds
+        // for their plot positions.
+        if (SableCompat.isOnSubLevel(blockEntity)) {
+            if (ext.renderingMode() != RenderingMode.IMMEDIATE) {
+                ext.renderingMode(RenderingMode.IMMEDIATE);
+            }
+            ext.terrainMeshReady(false);
+            phase = Phase.IDLE;
+            return ManagerTasks.FINISHED;
+        }
+
         if (!ext.supportedBlockEntity()
                 || !BBEConfig.OptEnabledTable.ENABLED[ext.optKind() & 0xFF]
                 || AltRenderers.hasRendererOverride(blockEntity.getType())) {
@@ -135,6 +148,16 @@ public final class InstancedBlockEntityManager {
      * Called from block entity animation tickers each tick to update animation state
      */
     public void tick(boolean animState, boolean animOption) {
+        // Sable compat: no BBE state tracking needed on sublevels; vanilla BER always renders.
+        if (SableCompat.isOnSubLevel(blockEntity)) {
+            this.setAnimating(false);
+            if (ext.renderingMode() != RenderingMode.IMMEDIATE) {
+                ext.renderingMode(RenderingMode.IMMEDIATE);
+            }
+            ext.terrainMeshReady(false);
+            return;
+        }
+
         if (!animOption) {
             this.setAnimating(false);
             return;
@@ -153,6 +176,16 @@ public final class InstancedBlockEntityManager {
      * Called by event-driven animations (e.g., Decorated Pots)
      */
     public void trigger(float start, float duration, boolean animOption) {
+        // Sable compat: keep sublevel block entities on the vanilla path, no scheduling.
+        if (SableCompat.isOnSubLevel(blockEntity)) {
+            this.setAnimating(false);
+            if (ext.renderingMode() != RenderingMode.IMMEDIATE) {
+                ext.renderingMode(RenderingMode.IMMEDIATE);
+            }
+            ext.terrainMeshReady(false);
+            return;
+        }
+
         if (!animOption) {
             this.setAnimating(false);
             return;

--- a/common/src/main/java/betterblockentities/client/render/immediate/blockentity/misc/LidControllerSync.java
+++ b/common/src/main/java/betterblockentities/client/render/immediate/blockentity/misc/LidControllerSync.java
@@ -2,6 +2,7 @@ package betterblockentities.client.render.immediate.blockentity.misc;
 
 /* local */
 import betterblockentities.client.chunk.section.SectionUpdateDispatcher;
+import betterblockentities.client.compat.SableCompat;
 import betterblockentities.client.gui.config.ConfigCache;
 import betterblockentities.client.render.immediate.blockentity.extentions.BlockEntityExt;
 import betterblockentities.client.render.immediate.util.BlockVisibilityChecker;
@@ -70,7 +71,9 @@ public class LidControllerSync {
         ext.terrainMeshReady(false);
         ext.renderingMode(RenderingMode.IMMEDIATE);
 
-        if (requiresRebuild) {
+        // Sable compat: sublevel chests already render via vanilla BER; their plot
+        // positions are not part of main-world Sodium terrain, so skip the rebuild.
+        if (requiresRebuild && !SableCompat.isOnSubLevel(blockEntity)) {
             SectionUpdateDispatcher.queueRebuildAtBlockPos(blockEntity.getBlockPos());
         }
     }

--- a/common/src/main/java/betterblockentities/mixin/render/immediate/blockentity/BlockEntityRenderDispatcherMixin.java
+++ b/common/src/main/java/betterblockentities/mixin/render/immediate/blockentity/BlockEntityRenderDispatcherMixin.java
@@ -1,6 +1,7 @@
 package betterblockentities.mixin.render.immediate.blockentity;
 
 /* local */
+import betterblockentities.client.compat.SableCompat;
 import betterblockentities.client.gui.config.BBEConfig;
 import betterblockentities.client.render.immediate.blockentity.extentions.BlockEntityExt;
 import betterblockentities.client.render.immediate.blockentity.manager.InstancedBlockEntityManager;
@@ -79,7 +80,7 @@ public abstract class BlockEntityRenderDispatcherMixin {
         }
 
         BlockEntityExt ext = (BlockEntityExt)entity;
-        if (shouldManage(ext)) {
+        if (shouldManage(entity)) {
             boolean cancel = !ext.hasSpecialManager() || !SpecialBlockEntityManager.shouldRender(entity);
             if (CrumblingRenderContext.isActive()) {
                 renderCrumblingOnly(entity, tickDelta, matrices, consumer);
@@ -106,7 +107,13 @@ public abstract class BlockEntityRenderDispatcherMixin {
     }
 
     @Unique
-    private static boolean shouldManage(BlockEntityExt ext) {
+    private static boolean shouldManage(BlockEntity blockEntity) {
+        // Sable compat: sublevel (contraption) block entities are rendered by Sable's own
+        // dispatcher and never baked into Sodium terrain, so never cull their BER path.
+        if (SableCompat.isOnSubLevel(blockEntity)) {
+            return false;
+        }
+        BlockEntityExt ext = (BlockEntityExt) blockEntity;
         return ext.terrainRenderingReady()
                 && BBEConfig.OptEnabledTable.ENABLED[ext.optKind() & 0xFF];
     }
@@ -124,7 +131,7 @@ public abstract class BlockEntityRenderDispatcherMixin {
             Operation<Void> original
     ) {
         BlockEntityExt ext = (BlockEntityExt) blockEntity;
-        if (!shouldManage(ext)
+        if (!shouldManage(blockEntity)
                 || ext.optKind() != InstancedBlockEntityManager.OptKind.SIGN
                 || AltRenderers.hasRendererOverride(blockEntity.getType())) {
             original.call(blockEntity, runnable);

--- a/common/src/main/java/betterblockentities/mixin/sodium/pipeline/ChunkBuilderMeshingTaskMixin.java
+++ b/common/src/main/java/betterblockentities/mixin/sodium/pipeline/ChunkBuilderMeshingTaskMixin.java
@@ -2,6 +2,7 @@ package betterblockentities.mixin.sodium.pipeline;
 
 /* local */
 import betterblockentities.client.chunk.pipeline.BBEBlockRenderer;
+import betterblockentities.client.compat.SableCompat;
 import betterblockentities.client.render.immediate.blockentity.extentions.BlockEntityExt;
 
 /* minecraft */
@@ -46,6 +47,12 @@ public abstract class ChunkBuilderMeshingTaskMixin {
         final BlockEntity blockEntity = BBEBlockRenderer.tryGetBlockEntity(slice, blockPos);
         if (blockEntity == null || !(blockEntity instanceof BlockEntityExt ext) || !ext.supportedBlockEntity()) {
             return RenderShape.INVISIBLE;
+        }
+
+        // Sable compat: leave sublevel block entities at their vanilla render shape.
+        // They are rendered by Sable's own dispatcher, not Sodium main-world terrain.
+        if (SableCompat.isOnSubLevel(blockEntity)) {
+            return renderShape;
         }
 
         return RenderShape.MODEL;


### PR DESCRIPTION
## Problem

When a supported block entity is placed on a Sable sublevel (Create: Aeronautics contraption), it is invisible until the player interacts with it (e.g. opening a chest makes it pop into view).

## Root cause

A newly constructed block entity defaults to \enderingMode=TERRAIN\ + \	errainMeshReady=true\, so \BlockEntityRenderDispatcherMixin\ immediately culls the vanilla block-entity renderer (BER) while waiting for Sodium to bake the model into the terrain chunk.

Sable sublevels are never meshed by Sodium's main-world pipeline: they live in isolated plot chunks and are rendered by Sable's own \SubLevelRenderDispatcher\, which collects block entities for vanilla BER rendering and never bakes BBE static terrain models. Net effect: the block entity is culled from the BER path while no terrain mesh ever appears for it. Interacting with it flips BBE into \IMMEDIATE\ mode, re-enabling BER — matching the reported symptom exactly.

## Fix

New helper \client/compat/SableCompat\ detects (via reflection, so Sable stays an **optional** dependency — no crash and zero behaviour change when Sable is not installed) whether a block entity is inside a Sable sublevel (\Sable.HELPER.getContaining(BlockEntity)\). Sublevel block entities are then kept on the vanilla path permanently:

- \BlockEntityRenderDispatcherMixin.shouldManage()\ returns \alse\ for sublevel BEs (never cull their BER).
- \InstancedBlockEntityManager.run()/tick()/trigger()\ pins sublevel BEs to \IMMEDIATE\ + \	errainMeshReady=false\ and never queues main-world section rebuilds for their plot positions.
- \BBEBlockRenderer.emitBlockModel()\ skips baking sublevel BEs into Sodium main-world terrain.
- \ChunkBuilderMeshingTaskMixin\ leaves sublevel BEs at their vanilla render shape instead of forcing \MODEL\.
- \LidControllerSync.setImmediate()\ skips the (useless) main-world rebuild for sublevel chests.

## Testing

- Built \:neoforge:modJar -Pbuild.release\ — BUILD SUCCESSFUL, jar verified to contain the new class.
- Tested in-game (MC 1.21.1, NeoForge 21.1.228, Sodium 0.8.12, Sable + Create: Aeronautics): block entities placed on a contraption now render immediately with no interaction needed; main-world block entities behave as before.
- The no-Sable path is safe by construction (a single \Class.forName\ miss returns \alse\ → upstream behaviour), though not explicitly runtime-tested without Sable installed.

Happy to port this to \main\ as well if you'd like it there.